### PR TITLE
feat: support for specifying the git_branch argument of fastlane match

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,6 +41,7 @@ workflows:
         run_if: false
         inputs:
         - git_url: "git@github.com/test/test.git"
+        - git_branch: "master"
         - app_id: "com.test.app"
         - type: appstore
         - decrypt_password: "match_password_test"

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-tools/go-steputils/input"
+	"github.com/kballard/go-shellquote"
 )
 
 // ConfigsModel ...

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-tools/go-steputils/input"
-	"github.com/kballard/go-shellquote"
 )
 
 // ConfigsModel ...
@@ -35,6 +34,7 @@ type ConfigsModel struct {
 func createConfigsModelFromEnvs() ConfigsModel {
 	return ConfigsModel{
 		GitURL:          os.Getenv("git_url"),
+		GitBranch:       os.Getenv("git_branch"),
 		AppID:           os.Getenv("app_id"),
 		DecryptPassword: os.Getenv("decrypt_password"),
 		Type:            os.Getenv("type"),
@@ -50,6 +50,7 @@ func (configs ConfigsModel) print() {
 	log.Infof("Configs:")
 
 	log.Printf("- GitURL: %s", configs.GitURL)
+	log.Printf("- GitBranch: %s", configs.GitBranch)
 	log.Printf("- AppID: %s", configs.AppID)
 	log.Printf("- DecryptPassword: %s", input.SecureInput(configs.DecryptPassword))
 	log.Printf("- Type: %s", configs.Type)
@@ -294,6 +295,10 @@ func main() {
 
 	args = append(args, "--git_url", configs.GitURL)
 	args = append(args, "--app_identifier", configs.AppID)
+
+	if configs.GitBranch != "" {
+		args = append(args, "--git_branch", configs.GitBranch)
+	}
 
 	args = append(args, options...)
 

--- a/step.yml
+++ b/step.yml
@@ -73,9 +73,16 @@ inputs:
       title: "Match git url"
       summary: ""
       description: |-
-        The private git repostiry url where you have your
+        The private git repository url where you have your
         encrypted certificates and profiles
       is_required: true
+  - git_branch: ""
+    opts:
+      title: "Match git branch"
+      summary: ""
+      description: |-
+        The name of the git branch containing the encrypted
+        certificates and profiles. Uses master by default.
   - app_id: ""
     opts:
       title: "App ID"


### PR DESCRIPTION
This PR adds support for specifying the `--git_branch` argument for match in the case that users have per-team branches (as recommended by the fastlane team).

I do not have a lot of experience with go, so if you have any recommendations for improvements, please let me know and I can update as required.